### PR TITLE
システム環境設定のようにタイトルバーを非表示にする

### DIFF
--- a/NavigationSplitViewSettingsDemo/NavigationSplitViewSettingsDemo/NavigationSplitViewSettingsDemoApp.swift
+++ b/NavigationSplitViewSettingsDemo/NavigationSplitViewSettingsDemo/NavigationSplitViewSettingsDemoApp.swift
@@ -32,6 +32,24 @@ struct NavigationSplitViewSettingsDemoApp: App {
                 .frame(width: 720)
                 .environmentObject(generalSettings)
                 .environmentObject(advancedSettings)
+                // SettingsのNSWindowのタイトルバーを強引に隠すため、NSWindowの参照をNotificationCenterの通知で受け取る
+                .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeMainNotification)) { notification in
+                    if let window = notification.object as? NSWindow {
+                        // システム環境設定のようにタイトルバーを非表示にする
+                        window.titleVisibility = .hidden
+                        window.titlebarAppearsTransparent = true
+                        window.styleMask.insert(.fullSizeContentView)
+                        // 以下のようにするとタイトルバーが縦に長くなり、よりシステム環境設定ぽくなる (SettingsViewのtoolbar非表示をコメントアウトしてください)
+                        /*
+                        window.titleVisibility = .visible
+                        window.titlebarAppearsTransparent = true
+                        window.styleMask.insert(.titled)
+                        window.styleMask.insert(.fullSizeContentView)
+                        window.styleMask.insert(.unifiedTitleAndToolbar)
+                        window.toolbarStyle = .unified
+                        */
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION
https://qiita.com/IKEH/items/aa300913ccb126b4619e で知りました。macOSのSwiftUIの情報すくなくて助かります。

同じようにSettingsをよくするのはどうしたらいいか私も考えていたのですが、よりmacOS 13のシステム環境設定に近づけるならタイトルバーも非表示にするといいかなと思いました。
ただ、SwiftUIだけでは難しそうですね… NSWindowを直接いじらないとだめそうです。

試行錯誤したのですが結局SwiftUIだけだと現状難しそうだなと感じました(もしかしたらやりかたをみおとしてるかもしれません)。お試ししやすいようにサンプルコードをPull Requestとして作ってみました。マージはしなくて大丈夫です。

Pull Requestではコメントアウトしていますが、タイトルバーは残しつつツールバーと一緒に表示する形式のほうがよりシステム環境設定ぽいと感じました。
macOS 14からはサイドバー切り替えボタンを非表示にできるようなので、それがあるとより「ぽく」なりそうです。
https://developer.apple.com/documentation/swiftui/view/toolbar(removing:)

| タイトルバー非表示 | タイトルバー表示 |
| :--: | :--: |
| ![](https://github.com/pommdau/navigationsplitview-settings-demo/assets/1213991/e2451660-07e6-401b-94d3-11ada4b7536a) | ![](https://github.com/pommdau/navigationsplitview-settings-demo/assets/1213991/2a54f139-1da2-4fe2-8078-50b9fb9924b5) |